### PR TITLE
feat : 이전 달 가입자 수 조회

### DIFF
--- a/src/main/java/com/kh/jde/admin/controller/AdminController.java
+++ b/src/main/java/com/kh/jde/admin/controller/AdminController.java
@@ -313,6 +313,13 @@ public class AdminController {
 		return SuccessResponse.ok(newMemberCount, "최근 1개월 신규 가입자 수 조회 성공");
 	}
 	
+	// 이전 달 가입자 수
+	@GetMapping("/members/previous")
+	public ResponseEntity<SuccessResponse<Integer>> getNewMemberCountPreviousMonth(){
+		int previousMonthCount = adminService.getNewMemberCountPreviousMonth();
+		return SuccessResponse.ok(previousMonthCount, "이전 달 가입자 수 조회 성공");
+	}
+	
 	// 이용자 전체 수
 	@GetMapping("/members/total")
 	public ResponseEntity<SuccessResponse<Integer>> getTotalMemberCount(){

--- a/src/main/java/com/kh/jde/admin/model/dao/AdminMapper.java
+++ b/src/main/java/com/kh/jde/admin/model/dao/AdminMapper.java
@@ -145,4 +145,7 @@ public interface AdminMapper {
 	// 최근 1개월 신규 가입자 수 조회
 	int selectNewMemberCountLastMonth();
 	
+	// 이전 달 가입자 수 조회
+	int selectNewMemberCountPreviousMonth();
+	
 }

--- a/src/main/java/com/kh/jde/admin/model/service/AdminService.java
+++ b/src/main/java/com/kh/jde/admin/model/service/AdminService.java
@@ -102,6 +102,9 @@ public interface AdminService {
 	// 최근 1개월 신규 가입자 수 조회
 	int getNewMemberCountLastMonth();
 	
+	// 이전 달 가입자 수 조회
+	int getNewMemberCountPreviousMonth();
+	
 	// 이용자 전체 수 조회
 	int getTotalMemberCount();
 	

--- a/src/main/java/com/kh/jde/admin/model/service/AdminServiceImpl.java
+++ b/src/main/java/com/kh/jde/admin/model/service/AdminServiceImpl.java
@@ -439,6 +439,13 @@ public class AdminServiceImpl implements AdminService {
 		return adminMapper.selectNewMemberCountLastMonth();
 	}
 	
+	// 이전 달 가입자 수 조회
+	@Override
+	@Transactional(readOnly = true)
+	public int getNewMemberCountPreviousMonth() {
+		return adminMapper.selectNewMemberCountPreviousMonth();
+	}
+	
 	// 이용자 전체 수 조회
 	@Override
 	@Transactional(readOnly = true)

--- a/src/main/resources/mapper/admin-mapper.xml
+++ b/src/main/resources/mapper/admin-mapper.xml
@@ -1003,6 +1003,18 @@
 		   AND ENROLL_DATE >= ADD_MONTHS(SYSDATE, -1)
 	</select>
 	
+	<!-- 이전 달 가입자 수 조회 -->
+	<select id="selectNewMemberCountPreviousMonth" resultType="int">
+		SELECT
+		       COUNT(*)
+		  FROM
+		       TB_MEMBER
+		 WHERE
+		       STATUS = 'Y'
+		   AND ENROLL_DATE >= TRUNC(ADD_MONTHS(SYSDATE, -1), 'MM')
+		   AND ENROLL_DATE &lt; TRUNC(SYSDATE, 'MM')
+	</select>
+	
 	<!-- 리뷰 페이징 조회 -->
 	<select id="selectReviewList" resultType="ReviewListDTO">
 		SELECT


### PR DESCRIPTION
## 📌 작업 내용

- 이전 달의 가입자 수를 조회하는 기능입니다.

## 🔗 관련 이슈

-#이슈번호

## 📸 스크린샷 (선택)
<img width="535" height="531" alt="image" src="https://github.com/user-attachments/assets/9554edda-40b9-4d4b-9d62-82a0df417961" />

## ✅ 체크리스트

-[ V ] 코드가 정상 동작하는지 확인했습니다

## 🙏 리뷰어에게

- 저희 프로젝트가 1월에 시작이라서 아직 이전 달 가입자는 없습니다.
