### PR TITLE
fix: 댓글/ 댓글 전체 조회 - 비로그인 시 principal null값으로 인한 NPE 오류 해결 Feature/comment

### DIFF
--- a/src/main/java/com/kh/jde/comment/model/service/CommentServiceImpl.java
+++ b/src/main/java/com/kh/jde/comment/model/service/CommentServiceImpl.java
@@ -49,9 +49,11 @@ public class CommentServiceImpl implements CommentService {
 		// 4. 댓글 조회
 		List<CommentDTO> comments = commentMapper.getCommentList(reviewNo, pi);
 		
+		Long memberNo = (principal != null) ? principal.getMemberNo() : null;
+		
 		// 5. 댓글 본인 여부 추가
 		for(CommentDTO comment : comments) {
-			if(principal.getMemberNo().equals(comment.getMemberNo())) {
+			if(memberNo != null && memberNo.equals(comment.getMemberNo())) {
 				comment.setIsOwner("Y");
 			} else {
 				comment.setIsOwner("N");

--- a/src/main/java/com/kh/jde/review/controller/ReviewController.java
+++ b/src/main/java/com/kh/jde/review/controller/ReviewController.java
@@ -17,6 +17,7 @@ import com.kh.jde.auth.model.vo.CustomUserDetails;
 import com.kh.jde.common.responseData.SuccessResponse;
 import com.kh.jde.review.model.dto.BestReviewListResponse;
 import com.kh.jde.review.model.dto.BestReviewPagingRequest;
+import com.kh.jde.review.model.dto.KeywordDTO;
 import com.kh.jde.review.model.dto.QueryDTO;
 import com.kh.jde.review.model.dto.ReviewCreateRequest;
 import com.kh.jde.review.model.dto.ReviewListResponseDTO;
@@ -106,5 +107,11 @@ public class ReviewController {
 		List<BestReviewListResponse> result = reviewService.getBestReviewList(req);
 		
 		return SuccessResponse.ok(result, "베스트 리뷰 조회 성공");
+	}
+	
+	@GetMapping("/keywords")
+	public ResponseEntity<SuccessResponse<List<KeywordDTO>>> getKeywordList(){
+		
+		return SuccessResponse.ok(reviewService.getKeywordList(), "키워드 조회 성공");
 	}
 }

--- a/src/main/java/com/kh/jde/review/model/dao/ReviewMapper.java
+++ b/src/main/java/com/kh/jde/review/model/dao/ReviewMapper.java
@@ -10,6 +10,7 @@ import com.kh.jde.review.model.dto.BestReviewListResponse;
 import com.kh.jde.review.model.dto.BestReviewPagingRequest;
 import com.kh.jde.review.model.dto.CaptainQueryDTO;
 import com.kh.jde.review.model.dto.DetailReviewDTO;
+import com.kh.jde.review.model.dto.KeywordDTO;
 import com.kh.jde.review.model.dto.KeywordRowDTO;
 import com.kh.jde.review.model.dto.QueryDTO;
 import com.kh.jde.review.model.dto.RestaurantRequestDTO;
@@ -69,5 +70,7 @@ public interface ReviewMapper {
 	List<String> getUrlById(Long reviewNo);
 
 	List<BestReviewListResponse> getBestReviewList(BestReviewPagingRequest req);
+
+	List<KeywordDTO> getKeywordList();
 
 }

--- a/src/main/java/com/kh/jde/review/model/service/ReviewService.java
+++ b/src/main/java/com/kh/jde/review/model/service/ReviewService.java
@@ -6,6 +6,7 @@ import com.kh.jde.auth.model.vo.CustomUserDetails;
 import com.kh.jde.review.model.dto.BestReviewListResponse;
 import com.kh.jde.review.model.dto.BestReviewPagingRequest;
 import com.kh.jde.review.model.dto.DetailReviewDTO;
+import com.kh.jde.review.model.dto.KeywordDTO;
 import com.kh.jde.review.model.dto.QueryDTO;
 import com.kh.jde.review.model.dto.ReviewCreateRequest;
 import com.kh.jde.review.model.dto.ReviewListResponseDTO;
@@ -30,5 +31,7 @@ public interface ReviewService {
 	public void update(Long reviewNo, ReviewUpdateRequest review, CustomUserDetails principal);
 
 	public List<BestReviewListResponse> getBestReviewList(BestReviewPagingRequest req);
+
+	public List<KeywordDTO> getKeywordList();
 
 }

--- a/src/main/java/com/kh/jde/review/model/service/ReviewServiceImpl.java
+++ b/src/main/java/com/kh/jde/review/model/service/ReviewServiceImpl.java
@@ -18,6 +18,7 @@ import com.kh.jde.review.model.dto.BestReviewListResponse;
 import com.kh.jde.review.model.dto.BestReviewPagingRequest;
 import com.kh.jde.review.model.dto.CaptainQueryDTO;
 import com.kh.jde.review.model.dto.DetailReviewDTO;
+import com.kh.jde.review.model.dto.KeywordDTO;
 import com.kh.jde.review.model.dto.QueryDTO;
 import com.kh.jde.review.model.dto.RestaurantRequestDTO;
 import com.kh.jde.review.model.dto.RestaurantResponseDTO;
@@ -305,6 +306,11 @@ public class ReviewServiceImpl implements ReviewService {
 		
 		
 		return reviews;
+	}
+
+	@Override
+	public List<KeywordDTO> getKeywordList() {
+		return reviewMapper.getKeywordList();
 	}
 
 }

--- a/src/main/resources/mapper/review-mapper.xml
+++ b/src/main/resources/mapper/review-mapper.xml
@@ -864,5 +864,16 @@
 
 		FETCH FIRST #{scroll.sizePlusOne} ROWS ONLY
 	</select>
+	
+	<select id="getKeywordList" resultType="KeywordDTO">
+		SELECT
+				  KEYWORD_NO keywordNo
+				, KEYWORD_NAME keywordName
+		FROM
+				TB_KEYWORD
+		ORDER
+		BY
+				KEYWORD_NO ASC
+	</select>
 
 </mapper>


### PR DESCRIPTION
## 📌 작업 내용
- 비로그인 시 댓글 전체 조회가 안되는 오류를 고쳤습니다.
- principal = null일 경우 NPE 발생

## 🔗 관련 이슈

-#이슈번호

## 📸 스크린샷 (선택)

## ✅ 체크리스트

-[ 0 ] 코드가 정상 동작하는지 확인했습니다
-[ 0 ] 불필요한 console.log를 제거했습니다


## 🙏 리뷰어에게

- 추가 사항 있으면 말씀해주세요
